### PR TITLE
Missing v1 in style.json

### DIFF
--- a/style.json
+++ b/style.json
@@ -24,10 +24,10 @@
   "sources": {
     "openmaptiles": {
       "type": "vector",
-      "url": "https://byvekstavtale.leonard.io/tiles/bicycle//metadata.json"
+      "url": "https://byvekstavtale.leonard.io/tiles/bicycle/v1/metadata.json"
     }
   },
-  "sprite": "https://byvekstavtale.leonard.io/tiles/bicycle//sprite",
+  "sprite": "https://byvekstavtale.leonard.io/tiles/bicycle/v1/sprite",
   "glyphs": "https://byvekstavtale.leonard.io/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {


### PR DESCRIPTION
Add missing version parameter to URLs. Without this, the map didn't load for me when viewing `index.html`.

Thanks for sharing this cycling map style, I think it looks great!